### PR TITLE
Fix double callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,12 @@ GPIOAccessory.prototype.getServices = function() {
 
 GPIOAccessory.prototype.getOn = function(callback) {
     gpio.read(this.pin, function(err, value) {
-        if (err) callback(err);
-        var on = value;
-        callback(null, on);
+        if (err) {
+        	callback(err);
+        } else {
+	        var on = value;
+    	    callback(null, on);
+    	}
     });
 }
 


### PR DESCRIPTION
In case an error occurs, callback() is called twice, resulting in an exception.